### PR TITLE
Add support for tests with whole item

### DIFF
--- a/scrapytest/spec.py
+++ b/scrapytest/spec.py
@@ -11,11 +11,17 @@ class ItemSpec:
 
     class MyItemSpec:
         item_cls = MyItem
-        # with lambdas
+        # Test
+        ## with lambdas
         field_test = lambda value: 'failure' if value < 100 else ''
-        # with inbuilt testers
+        ## with inbuilt testers
         field2_test = Match('foobar\d+')
         field3_test = Type(int), MoreThan(1), LessThan(5)
+        # Test with whole item
+        name_int = lambda item: 'failure' if item['field'] < 100 else ''
+        # Coverage
+        field_cov = 0.5
+        field2_cov = 0.8
     """
     item_cls = NotImplemented
     tests = None

--- a/scrapytest/spec.py
+++ b/scrapytest/spec.py
@@ -20,18 +20,23 @@ class ItemSpec:
     item_cls = NotImplemented
     tests = None
     coverage = None
+    ints = None
     default_cov = 0.1
     default_test = Pass()
+    default_int = Pass()
 
     def __init__(self):
         self.coverage = {}
         self.tests = {}
         for k in dir(self):
-            if k.endswith('_test') and k != 'default_test':
+            if (k.endswith('_test') or k.endswith('_int')) and k != 'default_test':
                 funcs = getattr(self, k)
                 if not isinstance(funcs, (list, tuple)):
                     funcs = [funcs]
-                self.tests[k.split('_test')[0]] = Compose(*funcs)
+                if(k.endswith('_test')):
+                    self.tests[k.split('_test')[0]] = Compose(*funcs)
+                else:
+                    self.ints = Compose(*funcs)
             if k.endswith('_cov') and k != 'default_cov':
                 self.coverage[k.split('_cov')[0]] = getattr(self, k)
 

--- a/scrapytest/validate.py
+++ b/scrapytest/validate.py
@@ -140,6 +140,11 @@ class Validator:
                 return messages
             else:
                 return [f'Missing specification for {type(item)}']
+        
+        int_func = spec.ints or spec.default_int
+        for msg in int_func(item):
+            if msg:
+                messages.append(f'{obj_name(item)}: {msg}')
         for key, value in item.items():
             if self._field_is_missing(value):
                 continue

--- a/scrapytest/validate.py
+++ b/scrapytest/validate.py
@@ -129,7 +129,7 @@ class Validator:
     def validate_item(self, item: Item) -> List:
         """
         Validate item.
-        :param item: Srapy.Item object
+        :param item: Scrapy.Item object
         :return: list of messages if any failures are encountered
         """
         messages = []


### PR DESCRIPTION
This PR adds the possibility to write a test with the whole item you receive from the spider. It can be useful if attributes are related to each other.

I gave the tests the suffix "_int" because I had no better name. You can rename it if you want.